### PR TITLE
Commit complete

### DIFF
--- a/accounts/forms.py
+++ b/accounts/forms.py
@@ -39,6 +39,7 @@ class MagasinForm(forms.ModelForm):
             else:
                 soc = Societe.objects.filter(users=currentuser)
             self.fields['societe'].queryset = Societe.objects.filter(id__in=soc.values_list('id', flat=True))
+            self.fields['societe'].widget.attrs['disabled'] = True
         else:
             self.fields['societe'].queryset = Societe.objects.none()
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,5 @@
 [pytest]
-DJANGO_SETTINGS_MODULE = project.settings
-python_files = test_*.py
+DJANGO_SETTINGS_MODULE = DocString_PortFolio.settings
+python_paths = .
+django_find_project = true
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ coverage==7.8.1
 diff-match-patch==20241021
 Django==5.2.1
 django-cleanup==9.0.0
+django-countries==7.6.1
 django-environ==0.12.0
 django-import-export==4.3.7
 django-iso3166==10.1.1
@@ -18,6 +19,8 @@ django-pytest==0.2.0
 django-tailwind==4.0.1
 django-widget-tweaks==1.5.0
 et_xmlfile==2.0.0
+fake-factory==9999.9.9
+Faker==12.0.1
 idna==3.10
 iniconfig==2.1.0
 iso3166==2.1.1
@@ -25,11 +28,14 @@ Jinja2==3.1.6
 markdown-it-py==3.0.0
 MarkupSafe==3.0.2
 mdurl==0.1.2
+mixer==7.2.2
 openpyxl==3.1.5
 packaging==25.0
 pluggy==1.6.0
 Pygments==2.19.1
 pytest==8.3.5
+pytest-cov==6.2.1
+pytest-django==4.11.1
 python-dateutil==2.9.0.post0
 python-slugify==8.0.4
 PyYAML==6.0.2
@@ -41,8 +47,7 @@ sqlparse==0.5.3
 tablib==3.8.0
 text-unidecode==1.3
 types-python-dateutil==2.9.0.20250516
+typing_extensions==4.13.2
 tzdata==2025.2
 urllib3==2.4.0
-
-django-countries~=7.6.1
-Faker~=37.3.0
+wheel==0.45.1

--- a/templates/403.html
+++ b/templates/403.html
@@ -1,0 +1,96 @@
+{% extends 'base.html' %}
+{% load static tailwind_tags %}
+{% load i18n %}
+{% load widget_tweaks %}
+{% block content %}
+    <!-- Pages: Errors: 403 -->
+    <!-- Page Container -->
+    <div
+            id="page-container"
+            class="mx-auto flex w-full min-w-80 flex-col bg-gray-100 dark:bg-gray-900 dark:text-gray-100"
+    >
+        <!-- Page Content -->
+        <main id="page-content" class="flex max-w-full flex-auto flex-col">
+            <div
+                    class="relative flex min-h-dvh items-center overflow-hidden bg-white dark:bg-gray-800"
+            >
+                <!-- Left/Right Background -->
+                <div
+                        class="absolute top-0 bottom-0 left-0 -ml-44 w-48 bg-orange-50 md:-ml-28 md:skew-x-6 dark:bg-orange-500/10"
+                        aria-hidden="true"
+                ></div>
+                <div
+                        class="absolute top-0 right-0 bottom-0 -mr-44 w-48 bg-orange-50 md:-mr-28 md:skew-x-6 dark:bg-orange-500/10"
+                        aria-hidden="true"
+                ></div>
+                <!-- END Left/Right Background -->
+
+                <!-- Error Content -->
+                <div
+                        class="relative container mx-auto space-y-16 px-8 py-16 text-center lg:py-32 xl:max-w-7xl"
+                >
+                    <div>
+                        <div class="mb-5 text-orange-300 dark:text-orange-300/50">
+                            <svg
+                                    class="hi-outline hi-hand-raised inline-block size-12"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                    fill="none"
+                                    viewBox="0 0 24 24"
+                                    stroke-width="1.5"
+                                    stroke="currentColor"
+                                    aria-hidden="true"
+                            >
+                                <path
+                                        stroke-linecap="round"
+                                        stroke-linejoin="round"
+                                        d="M10.05 4.575a1.575 1.575 0 10-3.15 0v3m3.15-3v-1.5a1.575 1.575 0 013.15 0v1.5m-3.15 0l.075 5.925m3.075.75V4.575m0 0a1.575 1.575 0 013.15 0V15M6.9 7.575a1.575 1.575 0 10-3.15 0v8.175a6.75 6.75 0 006.75 6.75h2.018a5.25 5.25 0 003.712-1.538l1.732-1.732a5.25 5.25 0 001.538-3.712l.003-2.024a.668.668 0 01.198-.471 1.575 1.575 0 10-2.228-2.228 3.818 3.818 0 00-1.12 2.687M6.9 7.575V12m6.27 4.318A4.49 4.49 0 0116.35 15m.002 0h-.002"
+                                />
+                            </svg>
+                        </div>
+                        <div
+                                class="text-6xl font-extrabold text-orange-600 md:text-7xl dark:text-orange-500"
+                        >
+                            403
+                        </div>
+                        <div
+                                class="mx-auto my-6 h-1.5 w-12 rounded-lg bg-gray-200 md:my-10 dark:bg-gray-700"
+                                aria-hidden="true"
+                        ></div>
+                        <h1 class="mb-3 text-2xl font-extrabold md:text-3xl">
+                            Not Your Lucky Day
+                        </h1>
+                        <h2
+                                class="mx-auto mb-5 font-medium text-gray-500 md:leading-relaxed lg:w-3/5 dark:text-gray-400"
+                        >
+                            Sorry, but it seems that today is not your lucky day. You don't have
+                            permission to access this page. Please try again tomorrow.
+                        </h2>
+                    </div>
+                    <a
+                            href="javascript:void(0)"
+                            class="group inline-flex items-center justify-center gap-2 rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm leading-5 font-semibold text-gray-800 hover:border-gray-300 hover:text-gray-900 hover:shadow-xs focus:ring-3 focus:ring-gray-300/25 active:border-gray-200 active:shadow-none dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300 dark:hover:border-gray-600 dark:hover:text-gray-200 dark:focus:ring-gray-600/40 dark:active:border-gray-700"
+                    >
+                        <svg
+                                class="hi-mini hi-arrow-left inline-block size-5 opacity-50 transition group-hover:opacity-100"
+                                xmlns="http://www.w3.org/2000/svg"
+                                viewBox="0 0 20 20"
+                                fill="currentColor"
+                                aria-hidden="true"
+                        >
+                            <path
+                                    fill-rule="evenodd"
+                                    d="M17 10a.75.75 0 01-.75.75H5.612l4.158 3.96a.75.75 0 11-1.04 1.08l-5.5-5.25a.75.75 0 010-1.08l5.5-5.25a.75.75 0 111.04 1.08L5.612 9.25H16.25A.75.75 0 0117 10z"
+                                    clip-rule="evenodd"
+                            />
+                        </svg>
+                        <span>Back to Dashboard</span>
+                    </a>
+                </div>
+                <!-- END Error Content -->
+            </div>
+        </main>
+        <!-- END Page Content -->
+    </div>
+    <!-- END Page Container -->
+    <!-- END Pages: Errors: 403 -->
+{% endblock %}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,29 @@
+import os
+import sys
+import django
+from django.conf import settings
+
 import pytest
+from django.contrib.auth.handlers.modwsgi import groups_for_user
+from django.contrib.auth.models import Group
+
 from accounts.models import JadUser, Societe, Magasin, Produit, Stock, Mouvements
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'DocString_PortFolio.settings')
+django.setup()
 
 
 @pytest.fixture
-def user_1():
-    return JadUser.objects.create_user(username='valdo', email='<valdo@gmail.com>', password='123456789')
+def user_1(group_1):
+    user_1 = JadUser.objects.create_user(email='<valdo@gmail.com>', fname='joe', lname='doe', password='Password123!')
+    user_1.save()
+    group_1.user_set.add(user_1)
+    return user_1
+
+
+@pytest.fixture
+def group_1():
+    group_1 = Group.objects.create(name='Magasinier')
+    return group_1

--- a/tests/unit_tests/test_menu.py
+++ b/tests/unit_tests/test_menu.py
@@ -1,0 +1,14 @@
+from django.test import Client
+
+from django.urls import reverse
+import pytest
+
+
+@pytest.mark.django_db
+def test_menu(user_1, group_1):
+    client = Client()
+    client.group = group_1
+    client.force_login(user_1)
+    url = reverse('societes')
+    response = client.get(url)
+    assert response.status_code == 403


### PR DESCRIPTION
First Test works

## Résumé par Sourcery

Implémente le contrôle d'accès basé sur les groupes pour SocieteListView en renvoyant une page 403 personnalisée pour les utilisateurs 'Magasinier', améliore le comportement du formulaire de compte, initialise les paramètres Django dans les fixtures de test, met à jour les dépendances du projet et ajoute des tests pour la nouvelle restriction.

Nouvelles fonctionnalités :
- Restreint l'accès à SocieteListView pour les utilisateurs du groupe 'Magasinier' en affichant une page d'erreur 403 personnalisée.

Corrections de bugs :
- S'assure que les utilisateurs sans sociétés associées n'ont aucune permission en effaçant user_permissions lorsque le nombre est zéro.

Améliorations :
- Désactive le champ societe dans les formulaires de compte pour les non-superutilisateurs.
- Intègre l'initialisation des paramètres Django et la configuration de sys.path dans les fixtures pytest.
- Ajoute un template 403.html dédié pour l'accès non autorisé.

Build :
- Met à jour requirements.txt pour inclure django-countries, fake-factory, Faker, mixer, pytest-django, pytest-cov et typing_extensions.

CI :
- Configure pytest.ini avec DJANGO_SETTINGS_MODULE, python_paths et django_find_project.

Tests :
- Restructure les fixtures pytest pour créer et associer des instances JadUser et Group.
- Ajoute un test unitaire pour vérifier que les utilisateurs restreints reçoivent une réponse 403 lorsqu'ils accèdent à la vue societes.

<details>
<summary>Original summary in English</summary>

## Résumé par Sourcery

Appliquer un contrôle d'accès basé sur les groupes sur la SocieteListView et améliorer la gestion des permissions, le comportement des formulaires, la configuration des tests, les mises à jour des dépendances et la configuration CI.

Nouvelles fonctionnalités :
- Restreindre l'accès à SocieteListView pour les utilisateurs du groupe 'Magasinier' avec une page 403 personnalisée.

Corrections de bugs :
- Effacer les user_permissions pour les utilisateurs sans sociétés associées afin d'empêcher tout accès non autorisé.

Améliorations :
- Désactiver le champ 'societe' dans les formulaires de compte pour les non-superutilisateurs.
- Initialiser les paramètres Django et sys.path dans les fixtures pytest pour prendre en charge l'exécution des tests.
- Ajouter un template 403.html dédié pour l'accès non autorisé.

Build :
- Mettre à jour requirements.txt pour inclure django-countries, fake-factory, Faker, mixer, pytest-django, pytest-cov et typing_extensions.

CI :
- Configurer pytest.ini avec DJANGO_SETTINGS_MODULE, python_paths et django_find_project.

Tests :
- Restructurer les fixtures pytest pour créer JadUser et Group et les associer.
- Ajouter un test unitaire garantissant que les utilisateurs restreints reçoivent une réponse 403 lors de l'accès à la vue societes.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce group-based access control on the SocieteListView and enhance permission handling, form behavior, testing setup, dependency updates, and CI configuration.

New Features:
- Restrict SocieteListView access for users in the 'Magasinier' group with a custom 403 page.

Bug Fixes:
- Clear user_permissions for users with no associated companies to prevent unauthorized access.

Enhancements:
- Disable the 'societe' field in account forms for non-superusers.
- Initialize Django settings and sys.path in pytest fixtures to support test execution.
- Add a dedicated 403.html template for unauthorized access.

Build:
- Update requirements.txt to include django-countries, fake-factory, Faker, mixer, pytest-django, pytest-cov, and typing_extensions.

CI:
- Configure pytest.ini with DJANGO_SETTINGS_MODULE, python_paths, and django_find_project.

Tests:
- Restructure pytest fixtures to create JadUser and Group and associate them.
- Add a unit test ensuring restricted users receive a 403 response when accessing the societes view.

</details>

</details>